### PR TITLE
Fix/dv 763 error code blocks

### DIFF
--- a/src/common/filters/all-exceptions.filter.ts
+++ b/src/common/filters/all-exceptions.filter.ts
@@ -33,7 +33,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
       : 'UnknownService';
 
     this.logger.error(
-      `[${serviceName}] Error ${status}: ${JSON.stringify(message)} (URL: ${request.url})`,
+      `[${serviceName}] ${status >= 500 ? 'Server Error' : 'Client Error'} ${status}: ${JSON.stringify(message)} (URL: ${request.url})`,
       stack,
     );
 

--- a/src/common/filters/all-exceptions.filter.ts
+++ b/src/common/filters/all-exceptions.filter.ts
@@ -17,15 +17,18 @@ export class AllExceptionsFilter implements ExceptionFilter {
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
 
-    const status =
-      exception instanceof HttpException
-        ? exception.getStatus()
-        : HttpStatus.INTERNAL_SERVER_ERROR;
+    let status = HttpStatus.INTERNAL_SERVER_ERROR;
+    let message = 'Internal server error';
 
-    const message =
-      exception instanceof HttpException
-        ? exception.getResponse()
-        : 'Internal server error';
+    if (exception instanceof HttpException) {
+      status = exception.getStatus();
+      const responseMessage = exception.getResponse();
+
+      message =
+        typeof responseMessage === 'string'
+          ? responseMessage
+          : (responseMessage as any).message || JSON.stringify(responseMessage);
+    }
 
     const stack = exception instanceof Error ? exception.stack : '';
     const serviceName = stack
@@ -33,7 +36,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
       : 'UnknownService';
 
     this.logger.error(
-      `[${serviceName}] ${status >= 500 ? 'Server Error' : 'Client Error'} ${status}: ${JSON.stringify(message)} (URL: ${request.url})`,
+      `[${serviceName}] Error ${status}: ${message} (URL: ${request.url})`,
       stack,
     );
 


### PR DESCRIPTION
blocks service is returning an “internal server error”, and it should throw a “bad request” error

wrong response:



```
{
    "statusCode": 500,
    "timestamp": "2025-02-05T16:54:12.313Z",
    "path": "/blocks?take=-5&cursor=6041534",
    "message": "Internal server error"
}
```

Expected response:

```
{
    "statusCode": 400,
    "timestamp": "2025-02-05T20:09:37.065Z",
    "path": "/blocks?take=-5&cursor=6041534",
    "message": {"Invalid \"take\" value: -5. Must be a positive integer."}
}
```